### PR TITLE
tc/INT-7084/change-org-fetch-assets-attachments

### DIFF
--- a/brandfolder/organization.py
+++ b/brandfolder/organization.py
@@ -1,8 +1,8 @@
 from brandfolder.resource import Resource
-from brandfolder.resource_container import ResourceContainer
-from brandfolder.brandfolder import Brandfolder
+from brandfolder.resource_container import ResourceContainer, ModifiedResourceContainer
 from brandfolder.asset import Asset
 from brandfolder.attachment import Attachment
+from brandfolder.brandfolder import Brandfolder
 
 
 class Organization(Resource):
@@ -11,9 +11,10 @@ class Organization(Resource):
 
     def __init__(self, client, **kwargs):
         super().__init__(client, **kwargs)
+        self.brandfolders = ResourceContainer(client, Brandfolder, parent=self)
+        self.assets = ModifiedResourceContainer(client, Asset, parent=self)
+        self.attachments = ModifiedResourceContainer(client, Attachment, parent=self)
 
-        self.assets = ResourceContainer(client, Asset, parent=self)
-        self.attachments = ResourceContainer(client, Attachment, parent=self)
 
     def __repr__(self):
         return f'<{self.resource_name} {self.attributes["slug"]}: {self.id}>'

--- a/brandfolder/resource_container.py
+++ b/brandfolder/resource_container.py
@@ -106,9 +106,6 @@ class ModifiedResourceContainer(ResourceContainer):
                     break
 
             return resources[-per:]
-
-        res = self.client.get(endpoint=self.endpoint, params=params, **kwargs)
-        included = res.get('included', [])
-
-        return [self.resource_class(self.client, data=data, included=included)
-                for data in res['data']]
+        else:
+            r = ResourceContainer(self.client, self.resource_class, self.parent)
+            return r.fetch(params=params, per=per, page=page, **kwargs)

--- a/brandfolder/resource_container.py
+++ b/brandfolder/resource_container.py
@@ -83,35 +83,29 @@ class ModifiedResourceContainer(ResourceContainer):
 
             while len(resources) < total_resources_to_fetch and not stop_op:
                 for i, brandfolder in enumerate(brandfolders):
-                    method = getattr(brandfolder, 'assets') \
-                        if self.resource_type == 'assets' \
-                        else getattr(brandfolder, 'attachments')
+                    method = getattr(brandfolder, 'assets') if self.resource_type == 'assets' else getattr(brandfolder,
+                                                                                                           'attachments')
 
                     stop_page_for_this_bf = False
                     p = 1
                     while stop_page_for_this_bf is False:
                         fetched_resources, meta = method.paginated_fetch(per=100, page=p, **kwargs)
                         resources.extend(fetched_resources)
-                        if len(resources) >= total_resources_to_fetch \
-                            or len(fetched_resources) == 0 \
-                            or meta['total_pages'] == p:
+                        if len(resources) >= total_resources_to_fetch or len(fetched_resources) == 0 or meta[
+                            'total_pages'] == p:
                             stop_page_for_this_bf = True
-                            if i == len(brandfolders) - 1:
-                                stop_op = True
-                                break
                         else:
                             p += 1
+
+                    if i == len(brandfolders) - 1:
+                        stop_op = True
+                        break
 
                 if len(resources) >= total_resources_to_fetch:
                     resources = resources[:total_resources_to_fetch]
                     break
-                elif len(resources) == 0:
-                    stop_op = True
-                    break
 
-            if resources:
-                resources = resources[-per:]
-            return resources
+            return resources[-per:]
 
         res = self.client.get(endpoint=self.endpoint, params=params, **kwargs)
         included = res.get('included', [])


### PR DESCRIPTION
# Background

[INT-7084](https://app.smartsheet.com/sheets/P8VGqVPRqr2CG2pqGgpM76RQvHFjvM4fmwGWgGx1?rowId=414777203265412)

The brandfolder squad is optimizing brandfolder endpoints and is going to remove endpoint "organizations/<org_id>/assets" and "organizations/<org_id>/attachments". To support them, we need to change all places in our repos that call those endpoints. 

# Execution 
This PR introduces a new class of ResourceContainer with a modified `fetch` method to handle this new logic. 