### PR TITLE
Remove assets and attachments resource containers from Organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ A valid Brandfolder API key is required for all actions. Find yours at https://b
 
 | :exclamation: | Deprecation Warning |
 |---------------|:------------------------|
-|  | Functionality to list assets and attachments by organization (`org.assets.fetch(...)` and `org.attachments.fetch(...)`) will soon be deprecated. ***This will be a breaking change for all versions.*** <br><br> Clients wishing to fetch these resources for an entire organization should instead list all Brandfolders for that organization, and then iteratively fetch assets or attachments from each section within a Brandfolder. <br><br> See the API documention for [listing assets](https://developers.brandfolder.com/docs/#list-assets) and [listing attachments](https://developers.brandfolder.com/docs/#list-attachments) for more information. |
+|  | Listing assets and attachments by organization (`org.assets.fetch(...)` and `org.attachments.fetch(...)`) was deprecated in v2.0.0. The Brandfolder API will drop support for these operations soon, which ***will be a breaking change for all versions of this SDK.*** <br><br> Clients wishing to fetch these resources for an entire organization should instead list all Brandfolders for that organization, and then iteratively fetch assets or attachments from each section within a Brandfolder. <br><br> See the API documention for [listing assets](https://developers.brandfolder.com/docs/#list-assets) and [listing attachments](https://developers.brandfolder.com/docs/#list-attachments) for more information. |
 
 <br>
 

--- a/brandfolder/organization.py
+++ b/brandfolder/organization.py
@@ -1,8 +1,5 @@
 from brandfolder.resource import Resource
 from brandfolder.resource_container import ResourceContainer
-from brandfolder.brandfolder import Brandfolder
-from brandfolder.asset import Asset
-from brandfolder.attachment import Attachment
 
 
 class Organization(Resource):
@@ -11,9 +8,6 @@ class Organization(Resource):
 
     def __init__(self, client, **kwargs):
         super().__init__(client, **kwargs)
-
-        self.assets = ResourceContainer(client, Asset, parent=self)
-        self.attachments = ResourceContainer(client, Attachment, parent=self)
 
     def __repr__(self):
         return f'<{self.resource_name} {self.attributes["slug"]}: {self.id}>'


### PR DESCRIPTION
Brandfolder is deprecating `/api/v4/organizations/{org_id}/assets` and `/api/v4/organizations/{org_id}/attachments`.

This PR removes `assets` and `attachments` from the `Organization` resource, which calls those endpoints.